### PR TITLE
MountedPathResolver Sort Fix

### DIFF
--- a/src/java/main/esg/node/filters/MountedPathResolver.java
+++ b/src/java/main/esg/node/filters/MountedPathResolver.java
@@ -87,9 +87,8 @@ public class MountedPathResolver implements esg.common.Resolver {
 
         Comparator<? super String> stringLengthComparator = new Comparator<String>() {
             public int compare(String o1, String o2) {
-                if(o1.length() > o2.length())      { return -1; }
-                else if(o1.length() < o2.length()) { return  1;}
-                else { return  0; }
+                if(o1.length() >= o2.length())      { return -1; }
+                else { return  1; }
             }
         };
                 


### PR DESCRIPTION
OK I just sent the pull request with the final fix (keeping sorted mount points)

Thanks

> > Here is the catalina.out we got after 1.6.2 upgrade on
> > esgf-node.ipsl.fr.
> > 5 mounts returned but only 4 mountpoints added, cordex project is
> > missing
> > so cordex data is not reachable:
> > 
> > ESGIni, Loading File:  /esg/config/esgcet/esg.ini
> > Mount Point: [test_dataroot] --> [/esg/data/test]
> > Mount Point: [euclipse] --> [/prodigfs/esg/EUCLIPSE]
> > Mount Point: [geomip] --> [/prodigfs/esg/GeoMIP]
> > Mount Point: [cordex] --> [/prodigfs/esg/CORDEX]
> > Mount Point: [esg_dataroot] --> [/prodigfs/esg]
> > esg.ini returning [5] mounts
> > Adding mountpoint: test_dataroot --> /esg/data/test
> > Adding mountpoint: esg_dataroot --> /prodigfs/esg
> > Adding mountpoint: euclipse --> /prodigfs/esg/EUCLIPSE
> > Adding mountpoint: geomip --> /prodigfs/esg/GeoMIP
> > 
> > After investigation, we realized that the addMountPoints method in
> > https://github.com/ESGF/esgf-node-manager/blob/master/src/java/main/esg/no
> > de/filters/MountedPathResolver.java
> > can not deal with project names that have the same length. like for
> > example geomip and cordex.
> > 
> > I made a dirty fix for this issue by just removing the sort
> > function. I
> > can publish the fixed jar and war if needed.
> > 
> > Thanks
